### PR TITLE
minor: Replace MAINTAINER with LABEL

### DIFF
--- a/docker_conf/all_in_one/Dockerfile
+++ b/docker_conf/all_in_one/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER Ishan <ishandutta2007@gmail.com>
+LABEL maintainer="Ishan <ishandutta2007@gmail.com>"
 
 # Set env variables
 ENV CHROME https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
MAINTAINER is deprecated.
rf. https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
I replaced with LABEL.