### PR TITLE
minor: Avoid using aliases

### DIFF
--- a/scripts/windows.ps1
+++ b/scripts/windows.ps1
@@ -1,35 +1,35 @@
-echo "FacebookPy Windows Setup"
-echo =============================================================================================
-echo "Installing Selenium"
+Write-Output "FacebookPy Windows Setup"
+Write-Output =============================================================================================
+Write-Output "Installing Selenium"
 pip install selenium
 python -m pip install pyvirtualdisplay
 py get-pip.py
-echo " "
-echo "Installing GUI Tool"
+Write-Output " "
+Write-Output "Installing GUI Tool"
 $webclient = New-Object System.Net.WebClient
 $webclient.DownloadFile("https://github.com/Nemixalone/GUI-tool-for-FacebookPy-script/releases/download/0.4/FacebookPy-GUI.exe","$pwd\FacebookPy-GUI.exe")
-mv "$pwd\FacebookPy-GUI.exe" "$pwd\..\FacebookPy-GUI.exe"
-echo " "
-cd ..\
-echo "Downloading Chrome Driver..."
+Move-Item "$pwd\FacebookPy-GUI.exe" "$pwd\..\FacebookPy-GUI.exe"
+Write-Output " "
+Set-Location ..\
+Write-Output "Downloading Chrome Driver..."
 $webclient = New-Object System.Net.WebClient
 $webclient.DownloadFile("https://chromedriver.storage.googleapis.com/2.34/chromedriver_win32.zip","$pwd\chromedriver.zip")
-echo "Chrome Driver download completed."
-echo " "
-echo "Unzipping Chrome Driver..."
+Write-Output "Chrome Driver download completed."
+Write-Output " "
+Write-Output "Unzipping Chrome Driver..."
 $shell = new-object -com shell.application
 $zip = $shell.NameSpace("$pwd\chromedriver.zip")
 foreach($item in $zip.items())
 {
 $shell.Namespace("$pwd\assets\").copyhere($item)
 }
-mv "$pwd\assets\chromedriver.exe" "$pwd\assets\chromedriver"
-echo "Unzipping completed."
-echo " "
-echo "Removing unneeded files..."
-rm chromedriver.zip
-echo "Removal completed."
-echo " "
+Move-Item "$pwd\assets\chromedriver.exe" "$pwd\assets\chromedriver"
+Write-Output "Unzipping completed."
+Write-Output " "
+Write-Output "Removing unneeded files..."
+Remove-Item chromedriver.zip
+Write-Output "Removal completed."
+Write-Output " "
 python setup.py install
-echo "Setup is completed."
+Write-Output "Setup is completed."
 pause


### PR DESCRIPTION
In powershell script files, we should use original commands not aliases, I think.
At now there mightn't be any problems, this change will probably be useful in the future.